### PR TITLE
OPHJOD-1441: Ensure 'Avainsanat' vocabulary exists and override embeddedTaxonomyCategory field to indicate category type based on vocabulary

### DIFF
--- a/modules/jod-ohjaaja-cms-tags/.gitignore
+++ b/modules/jod-ohjaaja-cms-tags/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+target/

--- a/modules/jod-ohjaaja-cms-tags/bnd.bnd
+++ b/modules/jod-ohjaaja-cms-tags/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: jod-ohjaaja-cms-tags
+Bundle-SymbolicName: fi.okm.jod.ohjaaja.cms.tags
+Bundle-Version: 1.0.0
+

--- a/modules/jod-ohjaaja-cms-tags/build.gradle
+++ b/modules/jod-ohjaaja-cms-tags/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id "com.diffplug.spotless" version "7.0.2"
+}
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api", version: "latest.release"
+}
+spotless {
+  java {
+    target 'src/*/**/*.java'
+    googleJavaFormat()
+    licenseHeader '''\
+    /*
+     * Copyright (c) $YEAR The Finnish Ministry of Education and Culture, The Finnish
+     * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+     * Education (Opetushallitus) and The Finnish Development and Administration centre
+     * for ELY Centres and TE Offices (KEHA).
+     *
+     * Licensed under the EUPL-1.2-or-later.
+     */
+
+     '''.stripIndent()
+  }
+}

--- a/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodCategoryType.java
+++ b/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodCategoryType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.ohjaaja.cms.tags;
+
+public enum JodCategoryType {
+  CATEGORY,
+  TAG,
+}

--- a/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodOhjaajaCmsTagsDtoConverter.java
+++ b/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodOhjaajaCmsTagsDtoConverter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.ohjaaja.cms.tags;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
+import java.util.Locale;
+import java.util.Map;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+    property = {
+      "application.name=Liferay.Headless.Admin.Taxonomy",
+      "dto.class.name=com.liferay.asset.kernel.model.AssetCategory",
+      "version=v1.0",
+      "service.ranking:Integer=100"
+    },
+    immediate = true,
+    service = DTOConverter.class)
+public class JodOhjaajaCmsTagsDtoConverter
+    implements DTOConverter<AssetCategory, JodTaxonomyCategory> {
+
+  @Reference private AssetCategoryLocalService assetCategoryLocalService;
+
+  @Reference private AssetVocabularyLocalService assetVocabularyLocalService;
+
+  @Reference private Portal portal;
+
+  private static final Log log = LogFactoryUtil.getLog(JodOhjaajaCmsTagsDtoConverter.class);
+
+  private static final String JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE = "jod-ohjaaja-cms-tags";
+
+  private static final long JOD_GROUP_ID = 20117;
+
+  @Override
+  public String getContentType() {
+    return JodTaxonomyCategory.class.getName();
+  }
+
+  @Override
+  public JodTaxonomyCategory toDTO(DTOConverterContext dtoConverterContext) throws Exception {
+    var assetCategory =
+        assetCategoryLocalService.getAssetCategory((Long) dtoConverterContext.getId());
+    return toJodTaxonomyCategory(assetCategory);
+  }
+
+  @Override
+  public JodTaxonomyCategory toDTO(
+      DTOConverterContext dtoConverterContext, AssetCategory assetCategory) {
+    return toJodTaxonomyCategory(assetCategory);
+  }
+
+  @Override
+  public JodTaxonomyCategory toDTO(AssetCategory assetCategory) {
+    return toJodTaxonomyCategory(assetCategory);
+  }
+
+  private JodTaxonomyCategory toJodTaxonomyCategory(AssetCategory assetCategory) {
+    try {
+      if (assetCategory.getVocabularyId() == 0) {
+        return null;
+      }
+
+      var assetVocabulary =
+          assetVocabularyLocalService.getAssetVocabulary(assetCategory.getVocabularyId());
+
+      if (assetVocabulary == null) {
+        return null;
+      }
+
+      return new JodTaxonomyCategory() {
+        {
+          setCategoryType(
+              JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE.equals(
+                      assetVocabulary.getExternalReferenceCode())
+                  ? JodCategoryType.TAG
+                  : JodCategoryType.CATEGORY);
+        }
+      };
+    } catch (PortalException portalException) {
+      return null;
+    }
+  }
+
+  @Activate
+  protected void activate() {
+    AssetVocabulary tagVocabulary;
+    try {
+      tagVocabulary =
+          assetVocabularyLocalService.getAssetVocabularyByExternalReferenceCode(
+              JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE, JOD_GROUP_ID);
+    } catch (PortalException e) {
+      log.info(
+          "No tag vocabulary found for JodTaxonomyCategory with external reference code "
+              + JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE);
+      tagVocabulary = null;
+    }
+
+    if (tagVocabulary == null) {
+      log.info(
+          "Creating tag vocabulary for JodTaxonomyCategory with external reference code "
+              + JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE);
+      try {
+        Map<Locale, String> titleMap =
+            Map.of(
+                LocaleUtil.fromLanguageId("en_US"),
+                "Tags",
+                LocaleUtil.fromLanguageId("fi_FI"),
+                "Avainsanat",
+                LocaleUtil.fromLanguageId("sv_SE"),
+                "Taggar");
+
+        var assetVocabularySettingsHelper = new AssetVocabularySettingsHelper();
+
+        assetVocabularySettingsHelper.setMultiValued(true);
+        assetVocabularySettingsHelper.setClassNameIdsAndClassTypePKs(
+            new long[] {portal.getClassNameId(JournalArticle.class.getName())},
+            new long[] {AssetCategoryConstants.ALL_CLASS_TYPE_PK},
+            new boolean[] {false});
+
+        var user = GuestOrUserUtil.getGuestOrUser(PortalUtil.getDefaultCompanyId());
+        tagVocabulary =
+            assetVocabularyLocalService.addVocabulary(
+                JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE,
+                user.getUserId(),
+                JOD_GROUP_ID,
+                "tags",
+                null,
+                titleMap,
+                null,
+                assetVocabularySettingsHelper.toString(),
+                AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+                new ServiceContext());
+      } catch (PortalException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    log.info(
+        "Found tag vocabulary for JodTaxonomyCategory with external reference code "
+            + JOD_TAG_VOCABULARY_EXTERNAL_REFERENCE_CODE
+            + ": "
+            + tagVocabulary.getName());
+  }
+}

--- a/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodTaxonomyCategory.java
+++ b/modules/jod-ohjaaja-cms-tags/src/main/java/fi/okm/jod/ohjaaja/cms/tags/JodTaxonomyCategory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.ohjaaja.cms.tags;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+public class JodTaxonomyCategory implements Serializable {
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  protected JodCategoryType categoryType;
+
+  @JsonIgnore
+  public void setCategoryType(JodCategoryType categoryType) {
+    this.categoryType = categoryType;
+  }
+}


### PR DESCRIPTION
### Description

This Liferay extension ensures that the "Avainsanat" vocabulary is created if it does not already exist, utilizing an external reference code that cannot be currently modified via the user interface. In addition, it overrides Liferay's default implementation of the taxonomy category embedding DTO converter (`com.liferay.headless.admin.taxonomy.internal.dto.v1_0.converter.TaxonomyCategoryDTOConverter`). By default, this class populates the `embeddedTaxonomyCategory` field within the objects of the `taxonomyCategoryBriefs` array when the API request includes the query parameter `nestedFields=embeddedTaxonomyCategory`. However, the information added by the default implementation is currently not relevant for our use case.

From a user interface perspective, it is more useful to indicate whether a given category belongs to the "Avainsanat" vocabulary. Therefore, our custom implementation sets the value of the `embeddedTaxonomyCategory` field to `{ categoryType: "TAG" }` when the category belongs to the "Avainsanat" vocabulary, and to `{ categoryType: "CATEGORY" }` otherwise.

### Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1441
