### PR TITLE
OPHJOD-1473: Add GA workflow for updating Liferay and Upgrade Liferay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,30 @@ jobs:
           path: |
             build/docker/*
 
+  upgrade_check:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      upgrade_required: ${{ steps.diff.outputs.upgrade_required }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse gradle.properties
+        id: parse
+        run: |
+          IMAGE=$(grep '^liferay.workspace.docker.image.liferay=' gradle.properties | cut -d'=' -f2 | xargs)
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Compare images and decide
+        id: diff
+        run: |
+          if [ "${{ steps.parse.outputs.image }}" != "${{ vars.JOD_LIFERAY_DOCKER_IMAGE }}" ]; then
+            echo "upgrade_required=true" >> $GITHUB_OUTPUT
+          else
+            echo "upgrade_required=false" >> $GITHUB_OUTPUT
+          fi
+
   package:
     needs: build
     permissions:
@@ -94,9 +118,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+
   deploy-dev:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    needs: package
+    if: (github.ref == 'refs/heads/main'  || github.event_name == 'workflow_dispatch') && needs.upgrade_check.outputs.upgrade_required == 'false'
+    needs:
+      - package
+      - upgrade_check
     uses: ./.github/workflows/deploy.yml
     permissions:
       id-token: write
@@ -106,10 +133,11 @@ jobs:
       tag: ${{ needs.package.outputs.tag }}
 
   deploy-test:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.upgrade_check.outputs.upgrade_required == 'false'
     needs:
       - package
       - deploy-dev
+      - upgrade_check
     uses: ./.github/workflows/deploy.yml
     permissions:
       id-token: write

--- a/.github/workflows/upgrade_liferay.yml
+++ b/.github/workflows/upgrade_liferay.yml
@@ -1,20 +1,10 @@
-name: deploy
+name: upgrade_liferay
 on:
-  workflow_call:
-    inputs:
-      environment:
-        type: string
-        description: 'Environment to deploy to'
-        required: true
-      tag:
-        type: string
-        description: 'Image tag to deploy'
-        required: true
   workflow_dispatch:
     inputs:
       environment:
         type: choice
-        description: 'Environment to deploy to'
+        description: 'Environment to upgrade'
         required: true
         default: 'dev'
         options:
@@ -26,18 +16,35 @@ on:
         required: true
 
 jobs:
-  deploy:
+  upgrade:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     concurrency:
-      group: deploy-${{ inputs.environment }}
+      group: upgrade-${{ inputs.environment }}
+
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.JOD_AWS_DEPLOY_ROLE_ARN }}
           aws-region: eu-west-1
+
+      - name: Take Aurora snapshot
+        id: snapshot
+        run: |
+          TS=$(date +%Y%m%d-%H%M%S)
+          SNAPSHOT_ID="${{ secrets.JOD_DB_CLUSTER_IDENTIFIER }}-snapshot-$TS"
+          echo "Creating snapshot $SNAPSHOT_ID"
+          aws rds create-db-cluster-snapshot \
+            --db-cluster-identifier "${{ secrets.JOD_DB_CLUSTER_IDENTIFIER }}" \
+            --db-cluster-snapshot-identifier "$SNAPSHOT_ID"
+          echo "snapshot_id=$SNAPSHOT_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for snapshot to be ready
+        run: |
+          aws rds wait db-cluster-snapshot-available \
+            --db-cluster-snapshot-identifier ${{ steps.snapshot.outputs.snapshot_id }}
 
       - name: Download task definition
         run: >
@@ -63,7 +70,28 @@ jobs:
           task-definition: task-definition.json
           container-name: ${{ vars.JOD_ECS_APP_CONTAINER }}
           image: ${{ secrets.JOD_ECR }}/oph/jod-ohjaaja-cms:${{ inputs.tag }}
-          environment-variables: "LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_AUTO_PERIOD_RUN=false"
+          environment-variables: "LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_AUTO_PERIOD_RUN=true"
+
+      - name: Scale ECS down
+        run: |
+          aws ecs update-service \
+            --cluster ${{ secrets.JOD_ECS_CLUSTER }} \
+            --service ${{ secrets.JOD_ECS_SERVICE }} \
+            --desired-count 0
+
+      - name: Wait until tasks are stopped
+        timeout-minutes: 10
+        run: |
+          while true; do
+            COUNT=$(aws ecs list-tasks \
+              --cluster ${{ secrets.JOD_ECS_CLUSTER }} \
+              --service-name ${{ secrets.JOD_ECS_SERVICE }} \
+              --desired-status RUNNING \
+              --query "taskArns" --output text | wc -w)
+            echo "Running tasks: $COUNT"
+            [ "$COUNT" -eq 0 ] && break
+            sleep 10
+          done
 
       - name: Deploy ECS Service
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
@@ -72,7 +100,6 @@ jobs:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
           service: ${{ secrets.JOD_ECS_SERVICE }}
           cluster: ${{ secrets.JOD_ECS_CLUSTER }}
-          wait-for-service-stability: true
 
       - name: Ensure that deploy worked
         run: |
@@ -89,3 +116,19 @@ jobs:
         run: >
           aws ssm put-parameter --overwrite --type String
           --name ${{ vars.JOD_IMAGE_TAG_PARAM }} --value "${TAG##*:}"
+
+      - name: Scale ECS up
+        run: |
+          aws ecs update-service \
+            --cluster ${{ secrets.JOD_ECS_CLUSTER }} \
+            --service ${{ secrets.JOD_ECS_SERVICE }} \
+            --desired-count 1
+
+      - name: Wait until ECS service is stable
+        timeout-minutes: 10
+        run: |
+          aws ecs wait services-stable \
+          --cluster ${{ secrets.JOD_ECS_CLUSTER }} \
+          --services ${{ secrets.JOD_ECS_SERVICE }}
+
+          echo "✅ Service is now stable and running updated tasks"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - default
 
   liferay:
-    image: jod-ohjaaja-cms-liferay:7.4.3.129-ga129
+    image: jod-ohjaaja-cms-liferay:7.4.3.132-ga132
     container_name: liferay1
     ports:
       - "8080:8080"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ liferay.workspace.wars.dir=modules
 microsoft.translator.subscription.key=
 liferay.workspace.product=portal-7.4-ga132
 target.platform.index.sources = true
-liferay.workspace.docker.image.liferay=liferay/portal:7.4.3.129-ga129
+liferay.workspace.docker.image.liferay=liferay/portal:7.4.3.132-ga132

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,4 @@ liferay.workspace.wars.dir=modules
 microsoft.translator.subscription.key=
 liferay.workspace.product=portal-7.4-ga132
 target.platform.index.sources = true
-#Temporary. Remove this when we upgrade Liferay to next release
 liferay.workspace.docker.image.liferay=liferay/portal:7.4.3.129-ga129


### PR DESCRIPTION
### Description

This PR introduces a safe and structured ECS deployment strategy for the dev and test environments, where automatic deployments are conditionally blocked based on Docker image version mismatches. It also includes a manually triggered upgrade workflow for controlled environment updates.

* A detection job compares the `liferay.workspace.docker.image.liferay` value in `gradle.properties` against the environment variable `JOD_LIFERAY_DOCKER_IMAGE`. If they differ, automatic deployment to dev or test is skipped. This prevents accidental deployment of unapproved versions.
* A manually triggered workflow (workflow_dispatch) is introduced to perform ECS upgrades. It:
  * Takes an Aurora DB cluster snapshot
  * Scales down the ECS service
  * Updates the task definition
  * Scales the service back up
  * Is not version-aware—you must explicitly provide the image tag and target environment (dev or test) as parameters.

### Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1473
