### PR TITLE
OPHJOD-2067: Add "View article" button to comments moderation view

### DIFF
--- a/configs/dev/portal-ext.properties
+++ b/configs/dev/portal-ext.properties
@@ -28,3 +28,4 @@ time.zones=\
         Europe/Helsinki
 ohjaaja.backend.url=http://backend.ohjaaja.jod.local:8080/ohjaaja
 konfo.api.study.programs.url=https://testiopintopolku.fi/konfo-backend/external/search/koulutukset?luokittelutermi=ohjaajakoulutukset&size=100
+ohjaaja.frontend.url=https://jodkehitys.fi/ohjaaja

--- a/configs/local/portal-ext.properties
+++ b/configs/local/portal-ext.properties
@@ -28,3 +28,4 @@ time.zones=\
         Europe/Helsinki
 ohjaaja.backend.url=http://host.docker.internal:9180/ohjaaja
 konfo.api.study.programs.url=https://testiopintopolku.fi/konfo-backend/external/search/koulutukset?luokittelutermi=ohjaajakoulutukset&size=100
+ohjaaja.frontend.url=http://localhost:8180/ohjaaja

--- a/configs/prod/portal-ext.properties
+++ b/configs/prod/portal-ext.properties
@@ -28,3 +28,4 @@ time.zones=\
         Europe/Helsinki
 ohjaaja.backend.url=http://backend.ohjaaja.jod.local:8080/ohjaaja
 konfo.api.study.programs.url=https://opintopolku.fi/konfo-backend/external/search/koulutukset?luokittelutermi=ohjaajakoulutukset&size=100
+ohjaaja.frontend.url=https://osaamispolku.fi/ohjaaja

--- a/configs/uat/portal-ext.properties
+++ b/configs/uat/portal-ext.properties
@@ -28,3 +28,4 @@ time.zones=\
         Europe/Helsinki
 ohjaaja.backend.url=http://backend.ohjaaja.jod.local:8080/ohjaaja
 konfo.api.study.programs.url=https://opintopolku.fi/konfo-backend/external/search/koulutukset?luokittelutermi=ohjaajakoulutukset&size=100
+ohjaaja.frontend.url=https://jodtestaus.fi/ohjaaja

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/dto/CommentReportSummaryDto.java
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/dto/CommentReportSummaryDto.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 public record CommentReportSummaryDto(
     UUID artikkelinKommenttiId,
+    String artikkeliErc,
     String kommentti,
     Instant kommentinAika,
     int kirjautuneetMaara,

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/portlet/CommentsModerationPortlet.java
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/portlet/CommentsModerationPortlet.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import fi.okm.jod.ohjaaja.cms.comments.moderation.client.Feature;
 import fi.okm.jod.ohjaaja.cms.comments.moderation.client.exception.ModerationApiException;
 import fi.okm.jod.ohjaaja.cms.comments.moderation.constants.CommentsModerationPortletKeys;
@@ -50,6 +51,8 @@ import org.osgi.service.component.annotations.Reference;
     service = Portlet.class)
 public class CommentsModerationPortlet extends MVCPortlet {
 
+  private static final String OHJAAJA_FRONTEND_URL = PropsUtil.get("ohjaaja.frontend.url");
+
   @Reference private CommentsModerationService commentsModerationService;
   @Reference private FeatureFlagsService featureFlagsService;
 
@@ -57,6 +60,8 @@ public class CommentsModerationPortlet extends MVCPortlet {
   public void doView(RenderRequest renderRequest, RenderResponse renderResponse)
       throws PortletException, IOException {
     try {
+      renderRequest.setAttribute(
+          "ohjaajaArticleShortUrlPrefix", OHJAAJA_FRONTEND_URL + "/fi/artikkeli/");
       renderRequest.setAttribute(
           "commentReportSummaries",
           commentsModerationService.getCommentReportSummaries(renderRequest));

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/AuditService.java
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/AuditService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 The Finnish Ministry of Education and Culture, The Finnish
+ * The Ministry of Economic Affairs and Employment, The Finnish National Agency of
+ * Education (Opetushallitus) and The Finnish Development and Administration centre
+ * for ELY Centres and TE Offices (KEHA).
+ *
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+package fi.okm.jod.ohjaaja.cms.comments.moderation.service;
+
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouter;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import javax.portlet.PortletRequest;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = AuditService.class)
+public class AuditService {
+  private static final Log log = LogFactoryUtil.getLog(AuditService.class);
+  @Reference private AuditRouter auditRouter;
+  @Reference private UserLocalService userLocalService;
+
+  public void audit(String action, PortletRequest portletRequest) {
+    ThemeDisplay themeDisplay = (ThemeDisplay) portletRequest.getAttribute(WebKeys.THEME_DISPLAY);
+    var userId = themeDisplay.getUserId();
+    try {
+      User user = userLocalService.getUser(userId);
+      AuditMessage auditMessage =
+          new AuditMessage(action, user.getCompanyId(), user.getUserId(), user.getFullName());
+      auditRouter.route(auditMessage);
+    } catch (Exception e) {
+      log.error("Audit failed for action " + action + " by user " + userId, e);
+    }
+  }
+}

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/CommentsModerationService.java
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/CommentsModerationService.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Reference;
 public class CommentsModerationService {
 
   @Reference private CommentsModerationApiClient commentsModerationApiClient;
+  @Reference private AuditService auditService;
 
   public List<CommentReportSummaryDto> getCommentReportSummaries(PortletRequest portletRequest)
       throws ModerationApiException {
@@ -33,10 +34,12 @@ public class CommentsModerationService {
   public void deleteCommentReports(UUID commentId, PortletRequest portletRequest)
       throws ModerationApiException {
     commentsModerationApiClient.deleteCommentReports(commentId, getToken(portletRequest));
+    auditService.audit("delete-comment-reports", portletRequest);
   }
 
   public void deleteComment(UUID commentId, PortletRequest portletRequest)
       throws ModerationApiException {
     commentsModerationApiClient.deleteComment(commentId, getToken(portletRequest));
+    auditService.audit("delete-comment", portletRequest);
   }
 }

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/FeatureFlagsService.java
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/java/fi/okm/jod/ohjaaja/cms/comments/moderation/service/FeatureFlagsService.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = FeatureFlagsService.class)
 public class FeatureFlagsService {
   @Reference private FeaturesApiClient featuresApiClient;
+  @Reference private AuditService auditService;
 
   public List<FeatureFlagDto> getFeatureFlags(PortletRequest portletRequest) {
     return featuresApiClient.getFeatureFlags(getToken(portletRequest));
@@ -38,5 +39,10 @@ public class FeatureFlagsService {
 
   public void updateFeatureFlag(PortletRequest portletRequest, Feature feature, boolean enabled) {
     featuresApiClient.setFeatureFlag(feature, enabled, getToken(portletRequest));
+    var eventType =
+        enabled
+            ? "feature-flag-" + feature.name() + "-enabled"
+            : "feature-flag-" + feature.name() + "-disabled";
+    auditService.audit(eventType, portletRequest);
   }
 }

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/META-INF/resources/view.jsp
@@ -1,9 +1,9 @@
 <%@ page import="com.liferay.portal.kernel.servlet.SessionErrors" %>
 <%@ page import="com.liferay.portal.kernel.servlet.SessionMessages" %>
 <%@ page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %>
+<%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 <%@ page import="fi.okm.jod.ohjaaja.cms.comments.moderation.dto.CommentReportSummaryDto" %>
 <%@ page import="javax.portlet.PortletRequest" %>
-<%@ page import="java.lang.Boolean" %>
 <%@ page import="java.sql.Date" %>
 <%@ page import="java.text.DateFormat" %>
 <%@ page import="java.util.List" %>
@@ -21,6 +21,7 @@
           .toList())
       .orElse(List.of());
   boolean commentsEnabled = Boolean.TRUE.equals(request.getAttribute("commentsEnabled"));
+  String ohjaajaArticleShortUrlPrefix = (String) request.getAttribute("ohjaajaArticleShortUrlPrefix");
   PortletRequest portletRequest = (PortletRequest) request.getAttribute("javax.portlet.request");
 
   Locale userLocale = themeDisplay.getLocale();
@@ -46,7 +47,6 @@
         onClick="return handleConfirmationRequiringButtonClick(this);"
         cssClass="btn btn-sm"/>
   </p>
-
 
 
   <p>
@@ -86,12 +86,12 @@
       <table class="table table-striped">
         <thead>
         <tr>
-          <th><liferay-ui:message key="comment"/></th>
+          <th style="width: 40%"><liferay-ui:message key="comment"/></th>
           <th><liferay-ui:message key="comment.time"/></th>
           <th><liferay-ui:message key="registered.count"/></th>
           <th><liferay-ui:message key="anonymous.count"/></th>
           <th><liferay-ui:message key="latest.report"/></th>
-          <th><liferay-ui:message key="actions"/></th>
+          <th style="width: 180px"><liferay-ui:message key="actions"/></th>
         </tr>
         </thead>
         <tbody>
@@ -106,7 +106,11 @@
         </portlet:actionURL>
 
         <tr>
-          <td><%=summary.kommentti()%>
+          <td style="max-width: 400px; white-space: pre-line; overflow: hidden; text-overflow: ellipsis; word-break: break-word;"
+              title="<%=HtmlUtil.escape(summary.kommentti())%>">
+            <div style="max-height: 280px; overflow: auto;">
+              <%=HtmlUtil.escape(summary.kommentti())%>
+            </div>
           </td>
           <td><%=dateFormat.format(Date.from(summary.kommentinAika()))%>
           </td>
@@ -117,19 +121,28 @@
           <td><%=dateFormat.format(Date.from(summary.viimeisinIlmianto()))%>
           </td>
           <td>
-            <aui:button
-                value='<%= themeDisplay.translate("button.delete.comment")%>'
-                data-url="${deleteCommentURL}"
-                data-msg='<%= themeDisplay.translate("confirm.delete.comment\")%>'
-                onClick="return handleConfirmationRequiringButtonClick(this);"
-                cssClass="btn btn-danger btn-sm"/>
+            <div style="display: flex; flex-direction: column; gap: 0.5em;">
+              <aui:button
+                  value='<%= themeDisplay.translate("button.delete.comment")%>'
+                  data-url="${deleteCommentURL}"
+                  data-msg='<%= themeDisplay.translate("confirm.delete.comment\")%>'
+                  onClick="return handleConfirmationRequiringButtonClick(this);"
+                  cssClass="btn btn-danger btn-sm"/>
 
-            <aui:button
-                value='<%= themeDisplay.translate("button.delete.reports")%>'
-                data-url="${deleteReportURL}"
-                data-msg='<%= themeDisplay.translate("confirm.delete.reports\")%>'
-                onClick="return handleConfirmationRequiringButtonClick(this);"
-                cssClass="btn btn-warning btn-sm"/>
+              <aui:button
+                  value='<%= themeDisplay.translate("button.delete.reports")%>'
+                  data-url="${deleteReportURL}"
+                  data-msg='<%= themeDisplay.translate("confirm.delete.reports\")%>'
+                  onClick="return handleConfirmationRequiringButtonClick(this);"
+                  cssClass="btn btn-warning btn-sm"/>
+
+              <aui:button
+                  value='<%= themeDisplay.translate("button.view.article")%>'
+                  href="<%=ohjaajaArticleShortUrlPrefix+summary.artikkeliErc()%>"
+                  target="_blank"
+                  cssClass="btn btn-secondary btn-sm"
+              />
+            </div>
           </td>
         </tr>
         <% } %>

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/content/Language.properties
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/content/Language.properties
@@ -7,6 +7,7 @@ page.description=Moderate comments and their reports submitted by users.
 no.comment.reports=No comment reports found.
 button.delete.comment=Delete comment
 button.delete.reports=Delete reports
+button.view.article=View article
 button.disable.comments=Disable comments
 button.enable.comments=Enable comments
 confirm.delete.comment=Are you sure you want to delete this comment?

--- a/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/content/Language_fi.properties
+++ b/modules/jod-ohjaaja-cms-comments-moderation/src/main/resources/content/Language_fi.properties
@@ -7,6 +7,7 @@ page.description=Moderoi käyttäjien lähettämiä kommentteja ja niiden ilmian
 no.comment.reports=Kommenttien ilmiantoja ei löytynyt.
 button.delete.comment=Poista kommentti
 button.delete.reports=Poista ilmoitukset
+button.view.article=Näytä artikkeli
 button.disable.comments=Poista kommentit käytöstä
 button.enable.comments=Ota kommentit käyttöön
 confirm.delete.comment=Haluatko varmasti poistaa kommentin?


### PR DESCRIPTION
### Description

Added "View article" button to the comments moderation view, making it easier for moderators to access the full context of a comment.

Improved comments moderation view for better usability and workflow.

Added audit logging for key actions:
* feature toggle changes
* comment deletions
* report deletions

### Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-2067
